### PR TITLE
Fix forceResync method

### DIFF
--- a/src/Client.jsx
+++ b/src/Client.jsx
@@ -198,6 +198,7 @@ class Client {
 
   forceResync() {
     Object.keys(this._stores).forEach((path) => {
+      this.sendToServer(new Client.Event.Subscribe({ path }));
       const { producer, refetching } = this._stores[path];
       const { hash } = producer;
       if(!refetching) {
@@ -259,8 +260,9 @@ class Client {
       if(__DEV__) {
         this._stores[path].refetching.should.be.true;
       }
-      this._stores[path].refetching = false;
       this._upgrade(path, remutable, { forceResync });
+    }).finally(() => {
+      this._stores[path].refetching = false;
     });
   }
 


### PR DESCRIPTION
This modification resends the subscriptions for all stores in the client and take care of keeping the refetching status consistent when the forceResync method is called.

Without this modification, some instability in case of link reconnect may occur.
